### PR TITLE
Update play/deps, add sending gauges

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,14 +21,14 @@ resolvers ++= Seq(
 // Dependencies
 
 libraryDependencies ++= Seq(
-    "play" %% "play" % "2.0"
+    "play" %% "play" % "2.0.3"
 )
 
 // Test dependencies
 
 libraryDependencies ++= Seq(
     "org.specs2" %% "specs2" % "1.9" % "test",
-    "play" %% "play-test" % "2.0" % "test"
+    "play" %% "play-test" % "2.0.3" % "test"
 )
 
 parallelExecution in Test := false

--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,14 @@ organization := "net.vz.play.statsd"
 
 scalaVersion := "2.9.1"
 
+resolvers ++= Seq(
+    DefaultMavenRepository,
+    Resolver.url("Play", url("http://download.playframework.org/ivy-releases/"))(Resolver.ivyStylePatterns),
+    "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/",
+    "Typesafe Other Repository" at "http://repo.typesafe.com/typesafe/repo/",
+    Resolver.url("sbt-plugin-releases", url("http://scalasbt.artifactoryonline.com/scalasbt/sbt-plugin-releases/"))(Resolver.ivyStylePatterns)
+)
+
 // Dependencies
 
 libraryDependencies ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -21,14 +21,14 @@ resolvers ++= Seq(
 // Dependencies
 
 libraryDependencies ++= Seq(
-    "play" %% "play" % "2.0.3"
+    "play" %% "play" % "2.0.4"
 )
 
 // Test dependencies
 
 libraryDependencies ++= Seq(
     "org.specs2" %% "specs2" % "1.9" % "test",
-    "play" %% "play-test" % "2.0.3" % "test"
+    "play" %% "play-test" % "2.0.4" % "test"
 )
 
 parallelExecution in Test := false

--- a/documentation/manual/home.textile
+++ b/documentation/manual/home.textile
@@ -38,6 +38,7 @@ Statsd.timing("my.frequent.operation", 10, 0.5)  // my operation took 50 ms. Sen
 Statsd.time("my.operation.i.dont.want.to.time.myself") {
   // do some stuff...
 } // This will get timed automatically.
+Statsd.gauge("my.value", 42)  // Record 42 for my.value
 
 p(note). Any errors will be logged, but will not cause the app to fail.
 
@@ -58,5 +59,6 @@ String result = Statsd.time("my.operation.i.dont.want.to.time.myself", new F.Fun
   public String apply() {
     return "some result";
   }}); // This will get timed automatically.
+Statsd.gauge("my.value", 42L)  // Record 42 for my.value
 
 p(note). Any errors will be logged, but will not cause the app to fail.

--- a/documentation/manual/home.textile
+++ b/documentation/manual/home.textile
@@ -16,7 +16,7 @@ h2. Configuration
 The following are configuration flags that belong in @conf/application.conf@:
 
 * @statsd.enabled@: Should be @true@ to use this module. Can be @false@ for testing.
-* @statsd.prefix@: The prefix for all stats sent by this app. They will appear in a folder of the same name on graphite.
+* @statsd.stat.prefix@: The prefix for all stats sent by this app. They will appear in a folder of the same name on graphite.
 * @statsd.host@: The hostname of the statsd server.
 * @statsd.port@: The port for the statsd server.
 
@@ -60,4 +60,3 @@ String result = Statsd.time("my.operation.i.dont.want.to.time.myself", new F.Fun
   }}); // This will get timed automatically.
 
 p(note). Any errors will be logged, but will not cause the app to fail.
-

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.11.3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,6 +11,6 @@ addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.6")
 
 addSbtPlugin("com.jsuereth" % "xsbt-gpg-plugin" % "0.6")
 
-addSbtPlugin("play" % "sbt-plugin" % "2.0.3")
+addSbtPlugin("play" % "sbt-plugin" % "2.0.4")
 
 addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.1.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,11 +4,10 @@ resolvers ++= Seq(
     "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/",
     "Typesafe Other Repository" at "http://repo.typesafe.com/typesafe/repo/",
     "sbt-idea-repo" at "http://mpeltonen.github.com/maven/",
-    Resolver.url("sbt-plugin-releases", url("http://scalasbt.artifactoryonline.com/scalasbt/sbt-plugin-releases/"))(Resolver.ivyStylePatterns),
-    "gseitz@github" at "http://gseitz.github.com/maven/"
+    Resolver.url("sbt-plugin-releases", url("http://scalasbt.artifactoryonline.com/scalasbt/sbt-plugin-releases/"))(Resolver.ivyStylePatterns)
 )
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.4")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.6")
 
 addSbtPlugin("com.jsuereth" % "xsbt-gpg-plugin" % "0.6")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,4 +11,4 @@ addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.6")
 
 addSbtPlugin("com.jsuereth" % "xsbt-gpg-plugin" % "0.6")
 
-addSbtPlugin("play" % "sbt-plugin" % "2.0")
+addSbtPlugin("play" % "sbt-plugin" % "2.0.3")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,3 +12,5 @@ addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.6")
 addSbtPlugin("com.jsuereth" % "xsbt-gpg-plugin" % "0.6")
 
 addSbtPlugin("play" % "sbt-plugin" % "2.0.3")
+
+addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.1.0")

--- a/src/main/java/play/modules/statsd/Statsd.java
+++ b/src/main/java/play/modules/statsd/Statsd.java
@@ -102,6 +102,16 @@ public class Statsd {
         });
     }
 
+    /**
+     * Record the given value.
+     *
+     * @param key The stat key to update.
+     * @param value The value to record for the stat.
+     */
+    public static void gauge(String key, long value) {
+        client().gauge(key, value);
+    }
+
     private static StatsdClient client() {
         return Statsd$.MODULE$;
     }

--- a/src/main/scala/play/modules/statsd/api/StatsdClient.scala
+++ b/src/main/scala/play/modules/statsd/api/StatsdClient.scala
@@ -28,6 +28,9 @@ trait StatsdClient {
   // Suffix for timing stats.
   private val TimingSuffix = "ms"
 
+  // Suffix for gauge stats.
+  private val GaugeSuffix = "g"
+
   /**
    * Increment a given stat key. Optionally give it a value and sampling rate.
    *
@@ -66,6 +69,16 @@ trait StatsdClient {
     result
   }
 
+  /**
+   * Record the given value.
+   *
+   * @param key The stat key to update.
+   * @param value The value to record for the stat.
+   */
+  def gauge(key: String, value: Long) {
+    safely { maybeSend(statFor(key, value, GaugeSuffix, 1.0), 1.0) }
+  }
+
   /*
    * ****************************************************************
    *                PRIVATE IMPLEMENTATION DETAILS
@@ -83,7 +96,6 @@ trait StatsdClient {
       case x if x >= 1.0 => "%s.%s:%s|%s".format(statPrefix, key, value, suffix)
       case _ => "%s.%s:%s|%s|@%f".format(statPrefix, key, value, suffix, samplingRate)
     }
-
   }
 
   /*

--- a/src/test/java/play/modules/statsd/StatsdTest.java
+++ b/src/test/java/play/modules/statsd/StatsdTest.java
@@ -42,6 +42,12 @@ public class StatsdTest {
     }
 
     @Test
+    public void gaugeShouldSendGaugeMessage() throws Exception {
+        Statsd.gauge("test", 42);
+        assertThat(receive(), equalTo("statsd.test:42|g"));
+    }
+
+    @Test
     public void incrementShouldSendIncrementByOneMessage() throws Exception {
         Statsd.increment("test");
         assertThat(receive(), equalTo("statsd.test:1|c"));

--- a/src/test/scala/play/modules/statsd/api/StatsdSpec.scala
+++ b/src/test/scala/play/modules/statsd/api/StatsdSpec.scala
@@ -8,6 +8,12 @@ import org.specs2.mutable.{Specification, BeforeAfter}
 case class StatsdSpec() extends Specification {
   sequential
   "Statsd" should {
+    "send gauge value" in new Setup {
+      running(fakeApp) {
+        Statsd.gauge("test", 42)
+        receive() mustEqual "statsd.test:42|g"
+      }
+    }
     "send increment by one message" in new Setup {
       running(fakeApp) {
         Statsd.increment("test")


### PR DESCRIPTION
The main addition is the ability to send gauges, for example: `Statsd.gauge("some.key", 42)` will send "some.key:42|g" to statsd.

There are also some minor updates that make it possible to build the project from scratch (e.g. sbt-release 0.4 was not found as gseitz' repo was not available).

JFYI: I also pushed this version to maven central (relocated under groupId `de.javakaffee.net.vz.play.statsd`, as I have publish permissions for de.javakaffee at sonatype) with version `1.0.0-rc2`.
